### PR TITLE
env: values can be just strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,8 @@
 language: php
 env:
   - DB=sqlite
-  - DB=mysql:
-      adapter: mysql2
-      database: test
-      username: 
-      encoding: utf8
-  - DB=postgres:
-      adapter: postgresql
-      database: test
-      username: postgres
+  - DB=mysql
+  - DB=postgres
 php:
   - 5.4
 before_script:


### PR DESCRIPTION
The `env:` key values can be just strings. They are then permutated and create a matrix, for each row of which you have the value `export`-ed. If you want to test against multiple databases, the `env:` technique is _just a convention_, your `before_script` lines need to do something with those env variable values.

At a minumum, you should not try to export values that will cause SSH sessions to wait on incomplete input. See [this doc guide](http://about.travis-ci.org/docs/user/languages/php/) and examples listed there (like Doctrine) to learn how this technique is used.
