### PR TITLE
Add setPdo, so people who already have a pdo can use the connection if t...

### DIFF
--- a/src/Aura/Sql/Connection/AbstractConnection.php
+++ b/src/Aura/Sql/Connection/AbstractConnection.php
@@ -223,6 +223,18 @@ abstract class AbstractConnection
 
     /**
      * 
+     * Set the PDO connection object, normally you don't need to
+     * 
+     * @return void
+     *
+     */
+    public function setPdo(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * 
      * Connects to the database by creating the PDO object.
      * 
      * @return void
@@ -231,7 +243,9 @@ abstract class AbstractConnection
     public function connect()
     {
         $this->preConnect();
-        $this->pdo = $this->newPdo();
+        if (! $this->pdo) {
+            $this->pdo = $this->newPdo();
+        }
         $this->postConnect();
     }
 


### PR DESCRIPTION
This PR is from the conversation over twitter https://twitter.com/stanlemon/status/274708971217100800

@stanlemon Thank you for the gist  https://gist.github.com/4180449 .

I don't think we need to pass in the options a pdo object as in the gist. I feel we can introduce public method called `setPdo()` . So the people don't get confused of whether they need to pass a Pdo really .

I will add tests for this if @pmjones thinks its ok for a merge. I want to wait and hear what he thinks about this.

Hope that is ok with him and let me know if this solves your problem really.

```
use Aura\Sql\ConnectionFactory;
$connection_factory = new ConnectionFactory;
$connection = $connection_factory->newInstance(
     // connection name
    'mysql',

    // DSN elements for PDO; this can also be
    // an array of key-value pairs
    'host=127.0.0.1;dbname=aura',

    // username for the connection
    'username',

    // password for the connection
    'password'
);

$params = array(
    'driver'    => 'pdo_mysql',
    'user'      => 'username',
    'password'  => 'password',
    'dbname'    => 'aura'
);

$dsn = 'mysql:host=localhost;dbname=' . $params['dbname'];

$pdo = new Pdo($dsn, $params['user'], $params['password'], $options = array(
        PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8',
    )
);

$connection->setPdo($pdo);
```

If you have any questions or concerns let me know.
