### PR TITLE
Add importing of a pdo instance to the Aura.Sql factory

### DIFF
--- a/src/Aura/Sql/Connection/AbstractConnection.php
+++ b/src/Aura/Sql/Connection/AbstractConnection.php
@@ -223,6 +223,18 @@ abstract class AbstractConnection
 
     /**
      * 
+     * Set the PDO connection object, normally you don't need to
+     * 
+     * @return void
+     *
+     */
+    public function setPdo(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * 
      * Connects to the database by creating the PDO object.
      * 
      * @return void
@@ -231,7 +243,9 @@ abstract class AbstractConnection
     public function connect()
     {
         $this->preConnect();
-        $this->pdo = $this->newPdo();
+        if (! $this->pdo) {
+            $this->pdo = $this->newPdo();
+        }
         $this->postConnect();
     }
 

--- a/src/Aura/Sql/ConnectionFactory.php
+++ b/src/Aura/Sql/ConnectionFactory.php
@@ -65,16 +65,23 @@ class ConnectionFactory
      */
     public function newInstance(
         $adapter,
-        $dsn,
+        $dsn = null,
         $username = null,
         $password = null,
         $options = []
     ) {
+        if ($adapter instanceof \Pdo) {
+            $pdo = $adapter;
+            $adapter = $pdo->getAttribute(\Pdo::ATTR_DRIVER_NAME);
+        } else {
+            $pdo = false;
+        }
+
         $class = $this->map[$adapter];
         $profiler = new Profiler;
         $column_factory = new ColumnFactory;
         $query_factory  = new QueryFactory;
-        return new $class(
+        $conn = new $class(
             $profiler,
             $column_factory,
             $query_factory,
@@ -83,5 +90,10 @@ class ConnectionFactory
             $password,
             $options
         );
+        
+        if ($pdo) {
+            $conn->setPdo($pdo);
+        }
+        return $conn;
     }
 }


### PR DESCRIPTION
This stems from: https://github.com/auraphp/Aura.Sql/pull/32

This pull request includes the changeset from @harikt's setpdo branch as well.

The end goal is to use this like so:
<?php
$dsn =

$pdo = new \Pdo('mysql:host=localhost;dbname=test', 'root', 'root');

$connection_factory = include '../Aura.Sql/scripts/instance.php';
$connection = $connection_factory->newInstance($pdo);
$connection->connect();

$results = $connection->fetchAll('SELECT \* FROM Person');
