### PR TITLE
ExtendedPdo::rollBack() return nothing

### DIFF
--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -782,6 +782,8 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
         $this->beginProfile(__FUNCTION__);
         $result = $this->pdo->rollBack();
         $this->endProfile();
+
+        return $result;
     }
     
     /**

--- a/tests/src/AbstractExtendedPdoTest.php
+++ b/tests/src/AbstractExtendedPdoTest.php
@@ -422,7 +422,7 @@ abstract class AbstractExtendedPdoTest extends \PHPUnit_Framework_TestCase
         $this->insert($cols);
         $actual = $this->pdo->fetchAll("SELECT * FROM pdotest");
         $this->assertSame(11, count($actual));
-        $this->pdo->rollback();
+        $rollBackResult = $this->pdo->rollback();
         $this->assertFalse($this->pdo->inTransaction());
         
         $actual = $this->pdo->fetchAll("SELECT * FROM pdotest");
@@ -438,6 +438,16 @@ abstract class AbstractExtendedPdoTest extends \PHPUnit_Framework_TestCase
         
         $actual = $this->pdo->fetchAll("SELECT * FROM pdotest");
         $this->assertSame(11, count($actual));
+
+        return $rollBackResult;
+    }
+
+    /**
+     * @depends testTransactions
+     */
+    public function testRollBack($rollBackResult)
+    {
+        $this->assertTrue($rollBackResult);
     }
     
     public function testProfiling()


### PR DESCRIPTION
Fixed to return the result of roll back.
