### PR TITLE
Fixed docs with return types and throws.

### DIFF
--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -344,7 +344,7 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
      * 
      * @return null
      * 
-     * @throws PDOException if the connection fails.
+     * @throws \PDOException if the connection fails.
      * 
      */
     public function connect()
@@ -569,7 +569,7 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
      * 
      * @param string $statement The SQL statement to prepare and execute.
      * 
-     * @return null
+     * @return int The number of rows affected.
      * 
      * @see http://php.net/manual/en/pdo.exec.php
      * 

--- a/src/ExtendedPdoInterface.php
+++ b/src/ExtendedPdoInterface.php
@@ -54,7 +54,7 @@ interface ExtendedPdoInterface extends PdoInterface
      * 
      * @return null
      * 
-     * @throws PDOException if the connection fails.
+     * @throws \PDOException if the connection fails.
      * 
      */
     public function connect();

--- a/src/PdoInterface.php
+++ b/src/PdoInterface.php
@@ -65,7 +65,7 @@ interface PdoInterface
      * 
      * @param string $statement The SQL statement to execute.
      * 
-     * @return null
+     * @return int The number of rows affected.
      * 
      * @see http://php.net/manual/en/pdo.exec.php
      * 
@@ -117,7 +117,7 @@ interface PdoInterface
      * @param array $options Set these attributes on the returned
      * PDOStatement.
      * 
-     * @return PDOStatement
+     * @return \PDOStatement
      * 
      * @see http://php.net/manual/en/pdo.prepare.php
      * 
@@ -139,7 +139,7 @@ interface PdoInterface
      * @param mixed $fetch_arg2 The second additional argument to send to
      * `PDOStatement::setFetchMode()`.
      * 
-     * @return PDOStatement
+     * @return \PDOStatement
      * 
      * @see http://php.net/manual/en/pdo.query.php
      */


### PR DESCRIPTION
- `ExtendedPdo::connect` throws `\PDOException`.
- `ExtendedPdo::exec` returns affected rows.
- `ExtendedPdoInterface::connect` throws `\PDOException`
  (slash needed, no use).
- `PdoInterface::exec` returns affected rows.
- `PdoInterface::prepare` returns `\PDOStatement`
  (slash needed).
- `PdoInterface::query` returns `\PDOStatement`
  (slash needed, no use).
