### PR TITLE
Import PDO into interface

### DIFF
--- a/src/PdoInterface.php
+++ b/src/PdoInterface.php
@@ -10,6 +10,8 @@
  */
 namespace Aura\Sql;
 
+use PDO;
+
 /**
  * 
  * An interface to the native PDO object.


### PR DESCRIPTION
I was mocking the Aura\Sql\ExtendedPdoInterface in PHPUnit 4.0 and I ran into an issue with it's mock generator:

```
PHPUnit 4.0.12 by Sebastian Bergmann.                                                                                                                                                                                


Fatal error: Class 'Aura\Sql\PDO' not found in /home/action/workspace/www/pp/vendor/phpunit/phpunit-mock-objects/src/Framework/MockObject/Generator.php on line 1041    
```

```
//in my test
$this->getMockBuilder('Aura\Sql\ExtendedPdoInterface')
     ->disableOriginalConstructor()
     ->getMock();
```

I ran the Aura\Sql tests after this change and it seemed fine.
