### PR TITLE
Use array_replace to merge attributes

### DIFF
--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -170,12 +170,8 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
         $this->dsn      = $dsn;
         $this->username = $username;
         $this->password = $password;
-        $this->options  = $options;
-    
-        // can't use array_merge, as it will renumber keys
-        foreach ((array) $attributes as $attribute => $value) {
-            $this->attributes[$attribute] = $value;
-        }
+        $this->options  = (array) $options;
+        $this->attributes = array_replace($this->attributes, (array) $attributes);
     }
 
     /**


### PR DESCRIPTION
I also casted options to array to ensure it is always an array because of the null default value, to avoid weird bugs (should it default to an empty array instead ?)
