### PR TITLE
Correctly handle zero-indexed placeholder arrays on execute

### DIFF
--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -864,16 +864,16 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
             return $this->prepare($statement);
         }
 
+        // match standard PDO execute() behavior of zero-indexed arrays
+        if (isset($values[0])) {
+            array_unshift($values, null);
+        }
+
         // rebuild the statement and values
         list($statement, $values) = $this->rebuild($statement, $values);
 
         // prepare the statement
         $sth = $this->prepare($statement);
-
-        // match standard PDO execute() behavior of zero-indexed arrays
-        if (isset($values[0])) {
-            array_unshift($values, null);
-        }
 
         // for the placeholders we found, bind the corresponding data values
         foreach ($values as $key => $val) {

--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -870,6 +870,11 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
         // prepare the statement
         $sth = $this->prepare($statement);
 
+        // match standard PDO execute() behavior of zero-indexed arrays
+        if (isset($values[0])) {
+            array_unshift($values, null);
+        }
+
         // for the placeholders we found, bind the corresponding data values
         foreach ($values as $key => $val) {
             $sth->bindValue($key, $val);

--- a/tests/src/AbstractExtendedPdoTest.php
+++ b/tests/src/AbstractExtendedPdoTest.php
@@ -534,6 +534,14 @@ abstract class AbstractExtendedPdoTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(3, count($res));
     }
 
+    public function testZeroIndexedPlaceholders()
+    {
+        $stm = 'SELECT * FROM pdotest WHERE id IN (?, ?, ?)';
+        $val = array(1, 2, 3);
+        $res = $this->pdo->fetchAll($stm, $val);
+        $this->assertSame(3, count($res));
+    }
+
     public function testPdoDependency()
     {
         // pass in ExtendedPdo to see if it can replace PDO


### PR DESCRIPTION
No test yet; opening the PR to get feedback/test-running. Fixes #75.
