### PR TITLE
Add HHVM compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - hhvm
 before_script:
   - cd tests
 script: phpunit

--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -416,6 +416,11 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
         array $ctor_args = array()
     ) {
         $sth = $this->perform($statement, $values);
+
+        if (!count($ctor_args)) {
+            return $sth->fetchObject($class_name);
+        }
+
         return $sth->fetchObject($class_name, $ctor_args);
     }
 
@@ -450,6 +455,11 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
         array $ctor_args = array()
     ) {
         $sth = $this->perform($statement, $values);
+
+        if (!count($ctor_args)) {
+            return $sth->fetchAll(self::FETCH_CLASS, $class_name);
+        }
+
         return $sth->fetchAll(self::FETCH_CLASS, $class_name, $ctor_args);
     }
 
@@ -694,10 +704,15 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
     {
         $this->connect();
         $this->beginProfile(__FUNCTION__);
-        $sth = call_user_func_array(
-            array($this->pdo, 'query'),
-            func_get_args()
-        );
+
+        // remove empty constructor params list if it exists
+        $args = func_get_args();
+        if (count($args) === 4 && $args[3] === array()) {
+            unset($args[3]);
+        }
+
+        $sth = call_user_func_array(array($this->pdo, 'query'), $args);
+
         $this->endProfile($sth->queryString);
         return $sth;
     }


### PR DESCRIPTION
If the class constructor arguments when fetching a class are provided, HHVM's behavior diverges from Zend. I've got an issue out for that. In the mean time, intentionally leaving off the parameter gets rid of the behavior difference, so everything actually works. Not a fan of adding what amounts to HHVM-specific checks, but it does get us another available runtime.

...which would resolve #72 
