### PR TITLE
Use explicit data type when binding.

### DIFF
--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -892,7 +892,18 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
 
         // for the placeholders we found, bind the corresponding data values
         foreach ($values as $key => $val) {
-            $sth->bindValue($key, $val);
+            if (is_int($val)) {
+                $param = self::PARAM_INT;
+            } else if (is_bool($val)) {
+                $param = self::PARAM_BOOL;
+            } else if (is_null($val)) {
+                $param = self::PARAM_NULL;
+            } else if (is_string($val)) {
+                $param = self::PARAM_STR;
+            } else {
+                $param = false;
+            }
+            $sth->bindValue($key, $val, $param);
         }
 
         // done


### PR DESCRIPTION
Using explicit data types helped me prevent errors when binding to a boolean column, without using explicit data types `false` can become `""` and have the query fail. This was tested in postgres. Optionally I could have cast to an integer when setting the bind value, but that shouldn't have to be the case.
