### PR TITLE
Optionally use PDO::FETCH_UNIQUE when building results array

### DIFF
--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -471,6 +471,8 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
      *
      * @param array $ctor_args Arguments to pass to each object constructor.
      *
+     * @param bool $unique Use PDO::FETCH_UNIQUE when building results array
+     *
      * @return array
      *
      */
@@ -478,15 +480,21 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
         $statement,
         array $values = array(),
         $class_name = 'StdClass',
-        array $ctor_args = array()
+        array $ctor_args = array(),
+        $unique = false
     ) {
         $sth = $this->perform($statement, $values);
+        $pdoOpts = self::FETCH_CLASS;
 
-        if ($ctor_args) {
-            return $sth->fetchAll(self::FETCH_CLASS, $class_name, $ctor_args);
+        if ($unique) {
+            $pdoOpts = $pdoOpts | self::FETCH_UNIQUE;
         }
 
-        return $sth->fetchAll(self::FETCH_CLASS, $class_name);
+        if ($ctor_args) {
+            return $sth->fetchAll($pdoOpts, $class_name, $ctor_args);
+        }
+
+        return $sth->fetchAll($pdoOpts, $class_name);
     }
 
     /**


### PR DESCRIPTION
When requesting objects, php returns an array with consecutive integers as the array key, as shown below. Adding [`PDO::FETCH_UNIQUE`](http://php.net/manual/en/pdo.constants.php#pdo.constants.fetch-unique) uses the first row as the indice (with the caveat of not being set in the object, unless it is selected twice.) This change default to false as not to cause any breaking changes.

Current output, indices are consecutive:

``` php
array(234) {
  [0]=>
  object(stdClass)#72 (5) {
    ["id"]=>
    string(1) "1"
    ["vendorId"]=>
    string(3) "215"
    ["name"]=>
    string(4) "Ajax"
    ["slug"]=>
    string(4) "ajax"
    ["sId"]=>
    string(1) "1"
  }
  [1]=>
  object(stdClass)#73 (5) {
    ["id"]=>
    string(1) "2"
    ["vendorId"]=>
    string(1) "3"
    ["name"]=>
    string(7) "Foo"
    ["slug"]=>
    string(7) "Foo"
    ["sId"]=>
    string(1) "1"
  }
}
```

Output when using FETCH_UNIQUE, indices are replaced with the first row (being `id` in this example):

``` php
array(234) {
  [1]=>
  object(stdClass)#72 (5) {
    ["vendorId"]=>
    string(3) "215"
    ["name"]=>
    string(4) "Ajax"
    ["slug"]=>
    string(4) "ajax"
    ["sId"]=>
    string(1) "1"
  }
  [2]=>
  object(stdClass)#73 (5) {
    ["vendorId"]=>
    string(1) "3"
    ["name"]=>
    string(7) "Foo"
    ["slug"]=>
    string(7) "Foo"
    ["sId"]=>
    string(1) "1"
  }
}
```
