### PR TITLE
fetchGroup()

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,12 @@ $result = $pdo->fetchAll($stm, $bind);
 // first column, and the row arrays are keyed on the column names
 $result = $pdo->fetchAssoc($stm, $bind);
 
-// fetchCol() returns a sequential array of all values in the first column
-$result = $pdo->fetchCol($stm, $bind);
+// fetchGroup() is like fetchAssoc() except that the values aren't wrapped in 
+// arrays. Instead, single column values are returned as a single dimensional
+// array and multiple columns are returned as an array of arrays
+// Third column specifies if more than a single column is to be returned
+// (i.e. there are more than two columns in the select)
+$result = $pdo->fetchGroup($stm, $bind, $singleColumn = true)
 
 // fetchObject() returns the first row as an object of your choosing; the
 // columns are mapped to object properties. an optional 4th parameter array

--- a/README.md
+++ b/README.md
@@ -231,9 +231,9 @@ $result = $pdo->fetchAssoc($stm, $bind);
 // fetchGroup() is like fetchAssoc() except that the values aren't wrapped in 
 // arrays. Instead, single column values are returned as a single dimensional
 // array and multiple columns are returned as an array of arrays
-// Third column specifies if more than a single column is to be returned
+// Set style to PDO::FETCH_NAMED when values are an array
 // (i.e. there are more than two columns in the select)
-$result = $pdo->fetchGroup($stm, $bind, $singleColumn = true)
+$result = $pdo->fetchGroup($stm, $bind, $style = PDO::FETCH_COLUMN)
 
 // fetchObject() returns the first row as an object of your choosing; the
 // columns are mapped to object properties. an optional 4th parameter array

--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -567,7 +567,8 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
      *
      * @param array $values Values to bind to the query.
      *
-     * @param bool $singleColoumn If the array value should also be an array
+     * @param int $style a fetch style defaults to PDO::FETCH_COLUMN for single 
+     *      values, use PDO::FETCH_NAMED when fetching a multiple columns
      *
      * @return array
      *
@@ -575,18 +576,10 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
     public function fetchGroup(
         $statement,
         array $values = array(),
-        $singleColumn = true
+        $style = self::FETCH_COLUMN
     ) {
-        $args = self::FETCH_GROUP;
-
-        if ($singleColumn) {
-            $args = $args | self::FETCH_COLUMN;
-        } else {
-            $args = $args | self::FETCH_NAMED;
-        }
-
         $sth = $this->perform($statement, $values);
-        return $sth->fetchAll($args);
+        return $sth->fetchAll(self::FETCH_GROUP | $style);
     }
 
     /**

--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -575,11 +575,11 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
     public function fetchGroup(
         $statement,
         array $values = array(),
-        $singleColoumn = true
+        $singleColumn = true
     ) {
         $args = self::FETCH_GROUP;
 
-        if ($singleColoumn) {
+        if ($singleColumn) {
             $args = $args | self::FETCH_COLUMN;
         } else {
             $args = $args | self::FETCH_NAMED;

--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -560,6 +560,37 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
 
     /**
      *
+     * Fetches multiple from the database as an associative array.
+     * The first column will be the index
+     *
+     * @param string $statement The SQL statement to prepare and execute.
+     *
+     * @param array $values Values to bind to the query.
+     *
+     * @param bool $singleColoumn If the array value should also be an array
+     *
+     * @return array
+     *
+     */
+    public function fetchGroup(
+        $statement,
+        array $values = array(),
+        $singleColoumn = true
+    ) {
+        $args = self::FETCH_GROUP;
+
+        if ($singleColoumn) {
+            $args = $args | self::FETCH_COLUMN;
+        } else {
+            $args = $args | self::FETCH_NAMED;
+        }
+
+        $sth = $this->perform($statement, $values);
+        return $sth->fetchAll($args);
+    }
+
+    /**
+     *
      * Gets a PDO attribute value.
      *
      * @param mixed $attribute The PDO::ATTR_* constant.

--- a/tests/unit/src/AbstractExtendedPdoTest.php
+++ b/tests/unit/src/AbstractExtendedPdoTest.php
@@ -378,7 +378,7 @@ abstract class AbstractExtendedPdoTest extends \PHPUnit_Framework_TestCase
     public function testGroupArray()
     {
         $stm = "SELECT id, name FROM pdotest WHERE id = 1";
-        $actual = $this->pdo->fetchGroup($stm, array(), false);
+        $actual = $this->pdo->fetchGroup($stm, array(), PDO::FETCH_NAMED);
         $expect = array(
             '1' => array(
                 array(

--- a/tests/unit/src/AbstractExtendedPdoTest.php
+++ b/tests/unit/src/AbstractExtendedPdoTest.php
@@ -363,6 +363,32 @@ abstract class AbstractExtendedPdoTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expect, $actual);
     }
 
+    public function testGroupSingleColumn()
+    {
+        $stm = "SELECT id, name FROM pdotest WHERE id = 1";
+        $actual = $this->pdo->fetchGroup($stm);
+        $expect = array(
+            '1' => array(
+                'Anna'
+            )
+        );
+        $this->assertEquals($expect, $actual);
+    }
+
+    public function testGroupArray()
+    {
+        $stm = "SELECT id, name FROM pdotest WHERE id = 1";
+        $actual = $this->pdo->fetchGroup($stm, array(), false);
+        $expect = array(
+            '1' => array(
+                array(
+                    'name' => 'Anna'
+                )
+            )
+        );
+        $this->assertEquals($expect, $actual);
+    }
+
     public function testFetchPairs()
     {
         $stm = "SELECT id, name FROM pdotest ORDER BY id";


### PR DESCRIPTION
Add a `fetchGroup()` fetch strategy that groups returned data by the first column. Unlike `fetchAssoc()`, `fetchGroup()`  returns a much flatter set of values.

Also added a test command (`composer test`) and set some variables for phpunit.
