### PR TITLE
Adds a close method to null out the connection

### DIFF
--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -634,6 +634,19 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
 
     /**
      *
+     * Closes the current connection by null-ing out the underlying PDO
+     * instance. Useful for long-running scripts to avoid connection timeouts.
+     *
+     * @return null
+     *
+     */
+    public function close()
+    {
+        $this->pdo = null;
+    }
+
+    /**
+     *
      * Returns the profiler object.
      *
      * @return ProfilerInterface

--- a/src/ExtendedPdoInterface.php
+++ b/src/ExtendedPdoInterface.php
@@ -219,6 +219,16 @@ interface ExtendedPdoInterface extends PdoInterface
 
     /**
      *
+     * Closes the current connection by null-ing out the underlying PDO
+     * instance. Useful for long-running scripts to avoid connection timeouts.
+     *
+     * @return null
+     *
+     */
+    public function close();
+
+    /**
+     *
      * Returns the profiler object.
      *
      * @return ProfilerInterface


### PR DESCRIPTION
Allows the manual closing out a connection to avoid issues with
long running scripts and timeouts. Method still has to be called
and has limited usefulness compared to re-connect options.
