### PR TITLE
Disconnect() Method for ExtendedPDO

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,1 +1,2 @@
+- CHG: ExtendedPdo::disconnect() added to allow manual disconnection of a connection
 - CHG: ExtendedPdo::prepare() now profiles the query-preparation time

--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -43,6 +43,15 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
 
     /**
      *
+     * The instance of PDO being decorated.
+     *
+     * @var PDO
+     *
+     */
+    protected $disconnected = false;
+
+    /**
+     *
      * The DSN for a lazy connection.
      *
      * @var string
@@ -210,6 +219,21 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
         // set attributes
         foreach ($this->attributes as $attribute => $value) {
             $this->setAttribute($attribute, $value);
+        }
+    }
+
+    /**
+     *
+     * Manual method that disconnects PDO and unsets PDO object
+     *
+     * @return null
+     *
+     */
+    public function disconnect()
+    {
+        if ($this->pdo) {
+            $this->disconnected = true;
+            $this->pdo = null;
         }
     }
 
@@ -628,7 +652,9 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
      */
     public function getPdo()
     {
-        $this->connect();
+        if ($this->disconnected === false) {
+            $this->connect();
+        }
         return $this->pdo;
     }
 

--- a/src/ExtendedPdoInterface.php
+++ b/src/ExtendedPdoInterface.php
@@ -30,6 +30,15 @@ interface ExtendedPdoInterface extends PdoInterface
 
     /**
      *
+     * Manual method that disconnects PDO and unsets PDO object
+     *
+     * @return null
+     *
+     */
+    public function disconnect();
+
+    /**
+     *
      * Performs a statement and returns the number of affected rows.
      *
      * @param string $statement The SQL statement to prepare and execute.
@@ -212,7 +221,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * Returns the underlying PDO connection object.
      *
-     * @return PDO
+     * @return PDO or Null if connection was manually disconnected
      *
      */
     public function getPdo();

--- a/tests/unit/src/ExtendedPdoTest.php
+++ b/tests/unit/src/ExtendedPdoTest.php
@@ -16,4 +16,13 @@ class ExtendedPdoTest extends AbstractExtendedPdoTest
         $this->assertInstanceOf('PDO', $lazy_pdo);
         $this->assertNotSame($this->pdo, $lazy_pdo);
     }
+
+    public function testDisconnect()
+    {
+        $lazy_pdo = $this->pdo;
+        $connected_pdo = $lazy_pdo->getPdo();
+        $this->assertNotEquals(null, $connected_pdo);
+        $lazy_pdo->disconnect();
+        $this->assertEquals(null, $lazy_pdo->getPdo());
+    }
 }


### PR DESCRIPTION
Currently the ExtendedPdo class has no mechanism for manually disconnecting from a SQL connection, relying soley on the SQL database to handle the connections. There are instances in which one needs a manual disconnect. This update added a disconnect() method along with tests and prevention logic in the getPDO to prevent an attempt to reconnection after the disconnection that could blow up the application.
