### PR TITLE
Fix for issue #96. Allow first bind value of query with numbered placeholders to be null

### DIFF
--- a/src/Rebuilder.php
+++ b/src/Rebuilder.php
@@ -92,7 +92,7 @@ class Rebuilder
     public function __invoke($statement, $values)
     {
         // match standard PDO execute() behavior of zero-indexed arrays
-        if (isset($values[0]) || array_key_exists(0, $values)) {
+        if (array_key_exists(0, $values)) {
             array_unshift($values, null);
         }
 

--- a/src/Rebuilder.php
+++ b/src/Rebuilder.php
@@ -92,7 +92,7 @@ class Rebuilder
     public function __invoke($statement, $values)
     {
         // match standard PDO execute() behavior of zero-indexed arrays
-        if (isset($values[0])) {
+        if (isset($values[0]) || array_key_exists(0, $values)) {
             array_unshift($values, null);
         }
 

--- a/tests/unit/src/AbstractExtendedPdoTest.php
+++ b/tests/unit/src/AbstractExtendedPdoTest.php
@@ -601,7 +601,7 @@ abstract class AbstractExtendedPdoTest extends \PHPUnit_Framework_TestCase
     public function testBindNullFirstParameter ()
     {
         $rebuilder = new Rebuilder($this->newExtendedPdo());
-        $result = $rebuilder('SELECT * FROM test WHERE column_one = ?', [null]);
+        $result = $rebuilder('SELECT * FROM test WHERE column_one = ?', array(null));
         $this->assertTrue(array_key_exists(1, $result[1]));
     }
 }

--- a/tests/unit/src/AbstractExtendedPdoTest.php
+++ b/tests/unit/src/AbstractExtendedPdoTest.php
@@ -597,4 +597,11 @@ abstract class AbstractExtendedPdoTest extends \PHPUnit_Framework_TestCase
         );
         $sth = $this->pdo->prepareWithValues($stm, array('id' => new StdClass));
     }
+
+    public function testBindNullFirstParameter ()
+    {
+        $rebuilder = new Rebuilder($this->newExtendedPdo());
+        $result = $rebuilder('SELECT * FROM test WHERE column_one = ?', [null]);
+        $this->assertTrue(array_key_exists(1, $result[1]));
+    }
 }


### PR DESCRIPTION
Fixes issue #96 provided with a test.
