### PR TITLE
throw exception when size of numbered placeholders does not matching size of input parameters

### DIFF
--- a/src/Exception/MissingParameter.php
+++ b/src/Exception/MissingParameter.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Sql\Exception;
+
+use Aura\Sql\Exception;
+
+/**
+ *
+ * Missing a parameter in the values bound to a statement
+ *
+ * @package Aura.Sql
+ *
+ */
+class MissingParameter extends Exception
+{
+}

--- a/src/Rebuilder.php
+++ b/src/Rebuilder.php
@@ -8,6 +8,8 @@
  */
 namespace Aura\Sql;
 
+use Aura\Sql\Exception\MissingParameter;
+
 /**
  *
  * This support class for ExtendedPdo rebuilds an SQL statement for automatic
@@ -202,6 +204,7 @@ class Rebuilder
      *
      * @return string The prepared query subpart.
      *
+     * @throws MissingParameter
      */
     protected function prepareNumberedPlaceholder($sub)
     {
@@ -217,6 +220,9 @@ class Rebuilder
         } else {
             // increase the count of numbered placeholders to be bound
             $this->count ++;
+            if (array_key_exists($this->num, $this->values) === false) {
+                throw new MissingParameter('Parameter ' . $this->num . ' is missing from the bound values');
+            }
             $this->final_values[$this->count] = $this->values[$this->num];
         }
 

--- a/tests/AbstractExtendedPdoTest.php
+++ b/tests/AbstractExtendedPdoTest.php
@@ -543,6 +543,13 @@ abstract class AbstractExtendedPdoTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(3, count($res));
     }
 
+    public function testNumberedPlaceholderMissing()
+    {
+        $this->setExpectedException('Aura\Sql\Exception\\MissingParameter');
+        $stm = "SELECT id, name FROM pdotest WHERE id = ? OR id = ?";
+        $this->pdo->fetchOne($stm, array(1));
+    }
+
     public function testZeroIndexedPlaceholders()
     {
         $stm = 'SELECT * FROM pdotest WHERE id IN (?, ?, ?)';


### PR DESCRIPTION
Now a `Undefined offset: 3` error is generated. This replaces that with a PDOException. Maybe I should introduce a separate exception for this. First see what you think.
