### PR TITLE
Adding callable argument to yield* methods

### DIFF
--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -1000,13 +1000,20 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
      *
      * @param array $values Values to bind to the query.
      *
-     * @return Iterator\AllIterator
+     * @param callable $callable A callable to be applied to each of the rows
+     * to be returned.
+     *
+     * @return Iterator
      *
      */
-    public function yieldAll($statement, array $values = array())
+    public function yieldAll($statement, array $values = array(), $callable = null)
     {
         $sth = $this->perform($statement, $values);
-        return new Iterator\AllIterator($sth);
+        $iterator = new Iterator\AllIterator($sth);
+        if ($callable) {
+            return new Iterator\MapIterator($iterator, $callable);
+        }
+        return $iterator;
     }
 
     /**
@@ -1017,13 +1024,20 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
      *
      * @param array $values Values to bind to the query.
      *
-     * @return Iterator\AssocIterator
+     * @param callable $callable A callable to be applied to each of the rows
+     * to be returned.
+     *
+     * @return Iterator
      *
      */
-    public function yieldAssoc($statement, array $values = array())
+    public function yieldAssoc($statement, array $values = array(), $callable = null)
     {
         $sth = $this->perform($statement, $values);
-        return new Iterator\AssocIterator($sth);
+        $iterator = new Iterator\AssocIterator($sth);
+        if ($callable) {
+            return new Iterator\MapIterator($iterator, $callable);
+        }
+        return $iterator;
     }
 
     /**
@@ -1034,13 +1048,20 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
      *
      * @param array $values Values to bind to the query.
      *
-     * @return Iterator\ColIterator
+     * @param callable $callable A callable to be applied to each of the rows
+     * to be returned.
+     *
+     * @return Iterator
      *
      */
-    public function yieldCol($statement, array $values = array())
+    public function yieldCol($statement, array $values = array(), $callable = null)
     {
         $sth = $this->perform($statement, $values);
-        return new Iterator\ColIterator($sth);
+        $iterator = new Iterator\ColIterator($sth);
+        if ($callable) {
+            return new Iterator\MapIterator($iterator, $callable);
+        }
+        return $iterator;
     }
 
     /**
@@ -1084,13 +1105,16 @@ class ExtendedPdo extends PDO implements ExtendedPdoInterface
      *
      * @param array $values Values to bind to the query.
      *
+     * @param callable $callable A callable to be applied to each of the rows
+     * to be returned.
+     *
      * @return Iterator\PairsIterator
      *
      */
-    public function yieldPairs($statement, array $values = array())
+    public function yieldPairs($statement, array $values = array(), $callable = null)
     {
         $sth = $this->perform($statement, $values);
-        return new Iterator\PairsIterator($sth);
+        return new Iterator\PairsIterator($sth, $callable);
     }
 
     /**

--- a/src/Iterator/MapIterator.php
+++ b/src/Iterator/MapIterator.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace Aura\Sql\Iterator;
+
+use Iterator;
+use IteratorIterator;
+
+/**
+ *  A MapIterator
+ *
+ * @package Aura.Sql
+ *
+ */
+class MapIterator extends IteratorIterator
+{
+    /**
+     * The function to be apply on all InnerIterator element
+     *
+     * @var callable
+     */
+    private $callable;
+
+    /**
+     * The Constructor
+     *
+     * @param Iterator $iterator
+     * @param callable $callable
+     */
+    public function __construct(Iterator $iterator, $callable)
+    {
+        parent::__construct($iterator);
+        $this->callable = $callable;
+    }
+
+    /**
+     * Get the value of the current element
+     */
+    public function current()
+    {
+        $iterator = $this->getInnerIterator();
+
+        return call_user_func($this->callable, $iterator->current());
+    }
+}

--- a/src/Iterator/PairsIterator.php
+++ b/src/Iterator/PairsIterator.php
@@ -21,16 +21,29 @@ use PDOStatement;
 class PairsIterator extends AbstractIterator
 {
     /**
+     * The function to be apply on all element
+     *
+     * @var callable
+     */
+    protected $callable;
+
+    /**
      *
      * Constructor.
      *
      * @param PDOStatement $statement PDO statement.
      *
      */
-    public function __construct(PDOStatement $statement)
+    public function __construct(PDOStatement $statement, $callable = null)
     {
         $this->statement = $statement;
         $this->statement->setFetchMode(PDO::FETCH_NUM);
+        if (! $callable) {
+            $callable = function (array $row) {
+                return $row;
+            };
+        }
+        $this->callable = $callable;
     }
 
     /**
@@ -43,6 +56,7 @@ class PairsIterator extends AbstractIterator
         $this->key = false;
         $this->row = $this->statement->fetch();
         if ($this->row !== false) {
+            $this->row = call_user_func($this->callable, $this->row);
             $this->key = $this->row[0];
             $this->row = $this->row[1];
         }

--- a/tests/AbstractExtendedPdoTest.php
+++ b/tests/AbstractExtendedPdoTest.php
@@ -240,6 +240,18 @@ abstract class AbstractExtendedPdoTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expect, $actual);
     }
 
+    public function testYieldAllWithCallback()
+    {
+        $callable = function ($row) {
+            return array(strtolower($row['name']));
+        };
+        $stm = "SELECT * FROM pdotest";
+        $expect = $this->pdo->fetchAll($stm, array(), $callable);
+        $actual = $this->iteratorIntoArray($this->pdo->yieldAll($stm, array(), $callable));
+
+        $this->assertEquals($expect, $actual);
+    }
+
     public function testFetchAssoc()
     {
         $stm = "SELECT * FROM pdotest ORDER BY id";
@@ -289,6 +301,18 @@ abstract class AbstractExtendedPdoTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expect, $actual);
     }
 
+    public function testYieldAssocWithCallback()
+    {
+        $callable = function ($row) {
+            return array(strtolower($row['name']));
+        };
+        $stm = "SELECT * FROM pdotest ORDER BY id";
+        $expect = $this->pdo->fetchAssoc($stm, array(), $callable);
+        $actual = $this->iteratorIntoArray($this->pdo->yieldAssoc($stm, array(), $callable));
+
+        $this->assertEquals($expect, $actual);
+    }
+
     public function testFetchCol()
     {
         $stm = "SELECT id FROM pdotest ORDER BY id";
@@ -323,6 +347,18 @@ abstract class AbstractExtendedPdoTest extends \PHPUnit_Framework_TestCase
 
         $expect = array(2, 4, 6, 8, 10);
         $this->assertEquals($expect, $result);
+    }
+
+    public function testYieldColWithCallback()
+    {
+        $callable = function ($val) {
+            return $val * 2;
+        };
+        $stm = "SELECT id FROM pdotest ORDER BY id LIMIT 5";
+        $expect = $this->pdo->fetchCol($stm, array(), $callable);
+        $actual = $this->iteratorIntoArray($this->pdo->yieldCol($stm, array(), $callable));
+
+        $this->assertEquals($expect, $actual);
     }
 
     public function testFetchObject()
@@ -492,6 +528,18 @@ abstract class AbstractExtendedPdoTest extends \PHPUnit_Framework_TestCase
           '10' => 'kara',
         );
         $this->assertSame($expect, $actual);
+    }
+
+    public function testYieldPairsWithCallback()
+    {
+        $callable = function ($row) {
+            return array((string) $row[0], strtolower($row[1]));
+        };
+        $stm = "SELECT id, name FROM pdotest ORDER BY id";
+        $expect = $this->pdo->fetchPairs($stm, array(), $callable);
+        $actual = $this->iteratorIntoArray($this->pdo->yieldPairs($stm, array(), $callable));
+
+        $this->assertEquals($expect, $actual);
     }
 
     public function testFetchValue()


### PR DESCRIPTION
Since Aura\SQL fetch\* methods can have an optional callable argument. I've added the same feature to the corresponding yield\* methods.
To do so:
- I've added a `MapIterator` class (inspired by the one I use on league/csv and downgraded it to work in PHP5.3) 
- I've updated the `PairsIterator` class to accept an optional callable
