### PR TITLE
Remove mb_ereg_* calls in 3.x

### DIFF
--- a/src/Parser/AbstractParser.php
+++ b/src/Parser/AbstractParser.php
@@ -218,8 +218,15 @@ abstract class AbstractParser implements ParserInterface
      */
     protected function handleSemiColon($state)
     {
-        $uselessCharacters = $state->capture(';\\s*');
-        $state->passString($uselessCharacters);
+        while (! $state->done())
+        {
+            $character = $state->getCurrentCharacter();
+            if (! in_array($character, array(';', "\r", "\n", "\t", " "), true))
+            {
+                break;
+            }
+            $state->passString($character);
+        }
         $state->setNewStatementCharacterFound(true);
     }
 

--- a/src/Parser/AbstractParser.php
+++ b/src/Parser/AbstractParser.php
@@ -117,7 +117,7 @@ abstract class AbstractParser implements ParserInterface
      */
     private function isStatementEmpty($statement)
     {
-        return mb_ereg_match('^\\s*$', $statement);
+        return trim($statement) === '';
     }
 
     /**

--- a/src/Parser/PgsqlParser.php
+++ b/src/Parser/PgsqlParser.php
@@ -90,10 +90,22 @@ class PgsqlParser extends AbstractParser
                 }
                 if (! $inCString) {
                     // Checking if we have blank characters until next quote. In which case it is the same string
-                    $blanks = $state->capture("\\s*'");
+                    $offset = 1;
+                    $blanks = true;
+                    while (! $state->done()) {
+                        $characterAtOffset = $state->getCharacterFromCurrent($offset);
+                        if ($characterAtOffset === "'") {
+                            break;
+                        }
+                        if (! in_array($characterAtOffset, array(" ", "\n", "\r", "\t"), true)) {
+                            $blanks = false;
+                            break;
+                        }
+                        $offset ++;                            
+                    }
                     if ($blanks) {
-                        $state->copyUntilCharacter("'");
                         $state->copyCurrentCharacter();
+                        $state->copyUntilCharacter("'");
                         $inCString = true;
                     }
                 }
@@ -110,7 +122,17 @@ class PgsqlParser extends AbstractParser
      */
     protected function handleDollar($state)
     {
-        $identifier = $state->capture('\\$([a-zA-Z_]\\w*)*\\$');
+        $identifier = '$';
+        $offset = 1;
+        while (! $state->done()) {
+            $character = $state->getCharacterFromCurrent($offset); 
+            $identifier .= $character;
+            if ($character === '$') {
+                break;
+            }
+            $offset ++;
+        }
+        
         if ($identifier) {
             // Copy until the end of the starting tag
             $state->copyUntilCharacter($identifier);

--- a/src/Parser/State.php
+++ b/src/Parser/State.php
@@ -331,12 +331,15 @@ class State
         if ($this->last_index <= $this->current_index) {
            return $capture;
         }
-        mb_regex_encoding($this->charset);
-        if (mb_ereg_search_init($this->statement) !== false) {
-            mb_ereg_search_setpos($this->current_index);
-            if ($matches = mb_ereg_search_regs('\\G' . $regexp)) {
-                $capture = isset($matches[$capture_group]) ? $matches[$capture_group] : '';
-            }
+        $regexp = "/\G{$regexp}/u";
+        if (preg_match_all(
+            $regexp,
+            $this->statement,
+            $matches,
+            PREG_SET_ORDER,
+            $this->current_index
+        )) {
+            $capture = isset($matches[$capture_group][0]) ? $matches[$capture_group][0] : '';
         }
         return $capture;
     }

--- a/src/Parser/State.php
+++ b/src/Parser/State.php
@@ -96,7 +96,7 @@ class State
             range('a', 'z'),
             range ('A', 'Z'),
             range (0, 9),
-            ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '_']
+            array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '_')
         );
     }
 
@@ -160,6 +160,16 @@ class State
     public function getCurrentCharacter()
     {
         return mb_substr($this->statement, $this->current_index, 1, $this->charset);
+    }
+
+    /**
+     * Returns the character $n position after the current character
+     * @param $n
+     * @return string
+     */
+    public function getCharacterFromCurrent($n)
+    {
+        return mb_substr($this->statement, $this->current_index + $n, 1, $this->charset);
     }
 
     /**
@@ -336,33 +346,6 @@ class State
             
         }
         return $identifier;
-    }
-
-    /**
-     *
-     * Tries to matche a regular expression starting at current index and returns the result
-     *
-     * @param string $regexp
-     * @param int $capture_group
-     * @return string
-     */
-    public function capture($regexp, $capture_group = 0)
-    {
-        $capture = '';
-        if ($this->last_index <= $this->current_index) {
-           return $capture;
-        }
-        $regexp = "/\G{$regexp}/u";
-        if (preg_match_all(
-            $regexp,
-            $this->statement,
-            $matches,
-            PREG_SET_ORDER,
-            $this->current_index
-        )) {
-            $capture = isset($matches[$capture_group][0]) ? $matches[$capture_group][0] : '';
-        }
-        return $capture;
     }
 
     /**

--- a/src/Parser/State.php
+++ b/src/Parser/State.php
@@ -69,6 +69,8 @@ class State
      */
     protected $new_statement_character_found = false;
 
+    protected $valid_placeholder_characters = [];
+    
     /**
      *
      * Constructor
@@ -90,6 +92,12 @@ class State
         if (array_key_exists(0, $this->values)) {
             array_unshift($this->values, null);
         }
+        $this->valid_placeholder_characters = array_merge(
+            range('a', 'z'),
+            range ('A', 'Z'),
+            range (0, 9),
+            ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '_']
+        );
     }
 
     /**
@@ -314,7 +322,20 @@ class State
      */
     public function getIdentifier()
     {
-        return $this->capture('\\w+\\b');
+        $identifier = '';
+        $length = 0;
+        while (! $this->done())
+        {
+            $character = mb_substr($this->statement, $this->current_index + $length, 1, $this->charset);
+            if (! in_array($character, $this->valid_placeholder_characters, true))
+            {
+                return $identifier;
+            }
+            $identifier .= $character;
+            $length++;
+            
+        }
+        return $identifier;
     }
 
     /**

--- a/tests/Parser/PgsqlParserTest.php
+++ b/tests/Parser/PgsqlParserTest.php
@@ -208,6 +208,10 @@ SQL;
         $sql = 'SELECT $outer$ nested strings $inner$:foo$inner$ $outer$';
         $parsedQuery = $this->parseSingleQuery($sql, $parameters);
         $this->assertEquals($sql, $parsedQuery->getString());
+
+        $sql = 'SELECT $€$hello$€$';
+        $parsedQuery = $this->parseSingleQuery($sql, $parameters);
+        $this->assertEquals($sql, $parsedQuery->getString());
     }
 
     public function testTypeCasting()

--- a/tests/Parser/PgsqlParserTest.php
+++ b/tests/Parser/PgsqlParserTest.php
@@ -176,8 +176,8 @@ SQL;
         $this->assertEquals($sql, $parsedQuery->getString());
 
         $sql = <<<SQL
-SELECT E'Multiline'
-'C-style escaping \' :foo \''
+SELECT E'Multiline'  
+       'C-style escaping \' :foo \' :foo'
 SQL;
         $parsedQuery = $this->parseSingleQuery($sql, $parameters);
         $this->assertEquals($sql, $parsedQuery->getString());
@@ -210,6 +210,10 @@ SQL;
         $this->assertEquals($sql, $parsedQuery->getString());
 
         $sql = 'SELECT $€$hello$€$';
+        $parsedQuery = $this->parseSingleQuery($sql, $parameters);
+        $this->assertEquals($sql, $parsedQuery->getString());
+
+        $sql = 'SELECT $€$hello$€';
         $parsedQuery = $this->parseSingleQuery($sql, $parameters);
         $this->assertEquals($sql, $parsedQuery->getString());
     }


### PR DESCRIPTION
@pavarnos @jlacoude This PR removes the `mb_ereg_*()` calls in favor of `preg_*()` calls, with `/u` modifiers (for UTF-8 support). This is to move away from deprecated ereg-related functionality, and to remov possible state issues.

The tests are unchanged and continue to pass; however, I'd like a separate set of eyes to look it over.

Let me know what you think!