### PR TITLE
Removed sqlsrv hack

### DIFF
--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -65,13 +65,6 @@ class ExtendedPdo extends AbstractExtendedPdo
             $options[PDO::ATTR_ERRMODE] = PDO::ERRMODE_EXCEPTION;
         }
 
-        // sqlsrv fails to connect when the error mode uses exceptions
-        $sqlsrvWarnEx = substr($dsn, 0, 7) == 'sqlsrv:'
-            && $options[PDO::ATTR_ERRMODE] == PDO::ERRMODE_EXCEPTION;
-        if ($sqlsrvWarnEx) {
-            $options[PDO::ATTR_ERRMODE] = PDO::ERRMODE_WARNING;
-        }
-
         // retain the arguments for later
         $this->args = [
             $dsn,

--- a/tests/ExtendedPdoTest.php
+++ b/tests/ExtendedPdoTest.php
@@ -672,14 +672,6 @@ class ExtendedPdoTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('[4]=>array(0) {}', $data);
     }
 
-    public function testSqlsrvErrmodeWarning()
-    {
-        $pdo = new ExtendedPdo('sqlsrv:bogus');
-        $data = $this->dump($pdo);
-        // options
-        $this->assertContains('[3]=>array(1) {[3]=>int(1)}', $data);
-    }
-
     protected function dump($pdo)
     {
         ob_start();


### PR DESCRIPTION
Removes a hack that completely blocks sqlsrv driver from using exceptions as an error mode.

The sqlsrv extension is now better maintained and this has been fixed for several versions.  https://github.com/Microsoft/msphpsql for the most recent.  If you're using a version old enough to still have issues, just set your own error mode in settings to something other than exception.. or upgrade the extension... really you should just upgrade your extension

Fixes #159 