### PR TITLE
Fixed error Class 'Aura\Sql\PDO' not found

### DIFF
--- a/src/ExtendedPdoInterface.php
+++ b/src/ExtendedPdoInterface.php
@@ -10,6 +10,7 @@ namespace Aura\Sql;
 
 use Aura\Sql\Parser\ParserInterface;
 use Aura\Sql\Profiler\ProfilerInterface;
+use PDO;
 
 /**
  *


### PR DESCRIPTION
prophecy is giving me this error when using the `ExtendedPdoInterface`:

```
✘ Fatal error happened while executing the following
    xxxx
    Class 'Aura\Sql\PDO' not found in ...\vendor\phpspec\prophecy\src\Prophecy\Doubler\Generator\ClassMirror.php on line 214
```

This is because `fetchGroup` is using a `PDO` constant.