### PR TITLE
Fix typo in branch 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ foreach ($pdo->yieldCol($stm, $bind) as $val) {
 // class name and optional array of constructor arguments.
 $class = 'ClassName';
 $args = ['arg0', 'arg1', 'arg2'];
-foreach ($pdo->yieldCol($stm, $bind, $class, $args) as $object) {
+foreach ($pdo->yieldObjects($stm, $bind, $class, $args) as $object) {
     // ...
 }
 


### PR DESCRIPTION
The same typo fix as for 3.x branch.