### PR TITLE
Fix bug with null value.

### DIFF
--- a/src/Parser/AbstractParser.php
+++ b/src/Parser/AbstractParser.php
@@ -210,7 +210,11 @@ abstract class AbstractParser implements ParserInterface
         }
 
         $expanded = [];
-        foreach ((array) $this->values[$this->num] as $value) {
+        $values = (array) $this->values[$this->num];
+        if (is_null($this->values[$this->num])) {
+            $values[] = null;
+        }
+        foreach ($values as $value) {
             $count = ++ $this->count['__'];
             $name = "__{$count}";
             $expanded[] = ":{$name}";

--- a/tests/Parser/AbstractParserTest.php
+++ b/tests/Parser/AbstractParserTest.php
@@ -24,11 +24,11 @@ abstract class AbstractParserTest extends \PHPUnit_Framework_TestCase
 
     public function testReplaceNumberedParameter()
     {
-        $parameters = ['bar', 'baz'];
-        $sql = "SELECT ? AS a, ? AS b";
+        $parameters = ['bar', 'baz', null];
+        $sql = "SELECT ? AS a, ? AS b FROM table WHERE id = ?";
         list ($statement, $values) = $this->rebuild($sql, $parameters);
-        $expectedStatement = "SELECT :__1 AS a, :__2 AS b";
-        $expectedValues = ['__1' => 'bar', '__2' => 'baz'];
+        $expectedStatement = "SELECT :__1 AS a, :__2 AS b FROM table WHERE id = :__3";
+        $expectedValues = ['__1' => 'bar', '__2' => 'baz', '__3' => null];
         $this->assertEquals($expectedStatement, $statement);
         $this->assertEquals($expectedValues, $values);
     }


### PR DESCRIPTION
When value is `null` `AbstractParser` will skip it and then query will failed.

To reproduce bug you can try query from tests.
