### PR TITLE
allow psr/log v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "psr/log": "^1|^2"
+        "psr/log": "^1.0 || ^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1|^2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
widens the restriction for which logger interface to use.
similar to how symfony handles this: https://github.com/symfony/console/blob/5.3/composer.json#L34