### PR TITLE
Update SqliteParser.php

### DIFF
--- a/src/Parser/SqliteParser.php
+++ b/src/Parser/SqliteParser.php
@@ -17,4 +17,20 @@ namespace Aura\Sql\Parser;
  */
 class SqliteParser extends AbstractParser
 {
+    /**
+     * {@inheritDoc}
+     */
+    protected $split = [
+        // single-quoted string
+        "'(?:[^'\\\\]|\\\\'?)*'",
+        // double-quoted string
+        '"(?:[^"\\\\]|\\\\"?)*"',
+        // backticked column names
+        '`(?:[^`\\\\]|\\\\`?)*`', 
+    ];
+  
+    /**
+     * {@inheritDoc}
+     */
+    protected $skip = '/^(\'|"|`|\:[^a-zA-Z_])/um';
 }


### PR DESCRIPTION
as describes here: https://github.com/auraphp/Aura.Sql/issues/183

in sqlite a columnname containing `:` is valid, however the sqlite queryparser currently does not support this.

adjusting the `$skip` and `$split` fixed it for us