### PR TITLE
Enable PHP 8.2 compat

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,6 +16,7 @@ jobs:
           - ubuntu-latest
         php-version:
           - '8.1'
+          - '8.2'
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/tests/FakeObject.php
+++ b/tests/FakeObject.php
@@ -1,7 +1,9 @@
 <?php
 namespace Aura\Sql;
 
-class FakeObject
+use stdClass;
+
+class FakeObject extends stdClass
 {
     public $foo;
 

--- a/tests/PdoDependent.php
+++ b/tests/PdoDependent.php
@@ -5,6 +5,9 @@ use PDO;
 
 class PdoDependent
 {
+    /** @var PDO */
+    private $pdo;
+
     public function __construct(PDO $pdo)
     {
         $this->pdo = $pdo;

--- a/tests/Profiler/ProfilerTest.php
+++ b/tests/Profiler/ProfilerTest.php
@@ -6,6 +6,9 @@ use Psr\Log\LogLevel;
 
 class ProfilerTest extends TestCase
 {
+    /** @var Profiler */
+    private $profiler;
+
     protected function setUp(): void
     {
         $this->profiler = new Profiler();


### PR DESCRIPTION
There are no changes in the source code. The current release `3.1.0` also works fine with PHP 8.2. This PR is just a fix for a problem in the test code in PHP8.2.

@see https://wiki.php.net/rfc/deprecate_dynamic_properties