### PR TITLE
Correct behaviour to match PHP 8.4 PDO returned types for connect and __construct for the internal pdo object

### DIFF
--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -104,9 +104,11 @@ class ExtendedPdo extends AbstractExtendedPdo
         // create a connection immediately
         if (isset($options[static::CONNECT_IMMEDIATELY])) {
             if($options[static::CONNECT_IMMEDIATELY]) {
+                unset($options[static::CONNECT_IMMEDIATELY]);
                 $this->establishConnection();
+            }else {
+                unset($options[static::CONNECT_IMMEDIATELY]);
             }
-            unset($options[static::CONNECT_IMMEDIATELY]);
         }
     }
 

--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -36,7 +36,7 @@ class ExtendedPdo extends AbstractExtendedPdo
 
     /**
      *
-     * Flag for how will construct the PDO object
+     * Flag for how to construct the PDO object
      *
      * @var bool
      */
@@ -75,7 +75,7 @@ class ExtendedPdo extends AbstractExtendedPdo
             $options[PDO::ATTR_ERRMODE] = PDO::ERRMODE_EXCEPTION;
         }
 
-        // check option for driver specific construct and set flay for lazy loading later
+        // check option for driver specific construct and set flag for lazy loading later
         if (isset($options[static::DRIVER_SPECIFIC])) {
             $this->driverSpecific = (bool) $options[static::DRIVER_SPECIFIC];
         }

--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -21,6 +21,9 @@ use PDO;
  */
 class ExtendedPdo extends AbstractExtendedPdo
 {
+    public const string CONNECT_IMMEDIATELY = 'immediate';
+    public const string DRIVER_SPECIFIC     = 'driverSpecific';
+
     /**
      *
      * Constructor arguments for instantiating the PDO connection.
@@ -30,6 +33,14 @@ class ExtendedPdo extends AbstractExtendedPdo
      */
     protected array $args = [];
 
+
+    /**
+     *
+     * Flag for how will construct the PDO object
+     *
+     * @var bool
+     */
+    protected bool $driverSpecific = false;
     /**
      *
      * Constructor.
@@ -64,6 +75,11 @@ class ExtendedPdo extends AbstractExtendedPdo
             $options[PDO::ATTR_ERRMODE] = PDO::ERRMODE_EXCEPTION;
         }
 
+        // check option for driver specific construct and set flay for lazy loading later
+        if (isset($options[static::DRIVER_SPECIFIC])) {
+            $this->driverSpecific = (bool) $options[static::DRIVER_SPECIFIC];
+        }
+
         // retain the arguments for later
         $this->args = [
             $dsn,
@@ -83,17 +99,24 @@ class ExtendedPdo extends AbstractExtendedPdo
 
         // set quotes for identifier names
         $this->setQuoteName($parts[0]);
+
+        // create a connection immediately
+        if (isset($options[static::CONNECT_IMMEDIATELY]) && $options[static::CONNECT_IMMEDIATELY]) {
+            $this->establishConnection();
+        }
     }
 
     public static function connect(
         string $dsn,
         ?string $username = null,
         ?string $password = null,
-        ?array $options = [],
+        ?array $options = null,
         array $queries = [],
         ?ProfilerInterface $profiler = null
     ): static {
-        return new static($dsn, $username, $password, $options ?? [], $queries, $profiler);
+        $options ??= [];
+        $options[static::DRIVER_SPECIFIC] = true;
+        return new static($dsn, $username, $password, $options, $queries, $profiler);
     }
 
     /**
@@ -111,7 +134,11 @@ class ExtendedPdo extends AbstractExtendedPdo
         // connect
         $this->profiler->start(__FUNCTION__);
         list($dsn, $username, $password, $options, $queries) = $this->args;
-        $this->pdo = PDO::connect($dsn, $username, $password, $options);
+        if ($this->driverSpecific) {
+            $this->pdo = PDO::connect($dsn, $username, $password, $options);
+        } else {
+            $this->pdo = new PDO($dsn, $username, $password, $options);
+        }
         $this->profiler->finish();
 
         // connection-time queries

--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -21,8 +21,8 @@ use PDO;
  */
 class ExtendedPdo extends AbstractExtendedPdo
 {
-    public const string CONNECT_IMMEDIATELY = 'immediate';
-    public const string DRIVER_SPECIFIC     = 'driverSpecific';
+    public const string CONNECT_IMMEDIATELY = 'auraSqlImmediate';
+    public const string DRIVER_SPECIFIC     = 'auraSqlDriverSpecific';
 
     /**
      *
@@ -78,6 +78,7 @@ class ExtendedPdo extends AbstractExtendedPdo
         // check option for driver specific construct and set flag for lazy loading later
         if (isset($options[static::DRIVER_SPECIFIC])) {
             $this->driverSpecific = (bool) $options[static::DRIVER_SPECIFIC];
+            unset($options[static::DRIVER_SPECIFIC]);
         }
 
         // retain the arguments for later
@@ -101,8 +102,11 @@ class ExtendedPdo extends AbstractExtendedPdo
         $this->setQuoteName($parts[0]);
 
         // create a connection immediately
-        if (isset($options[static::CONNECT_IMMEDIATELY]) && $options[static::CONNECT_IMMEDIATELY]) {
-            $this->establishConnection();
+        if (isset($options[static::CONNECT_IMMEDIATELY])) {
+            if($options[static::CONNECT_IMMEDIATELY]) {
+                $this->establishConnection();
+            }
+            unset($options[static::CONNECT_IMMEDIATELY]);
         }
     }
 

--- a/src/ExtendedPdo.php
+++ b/src/ExtendedPdo.php
@@ -106,7 +106,7 @@ class ExtendedPdo extends AbstractExtendedPdo
             if($options[static::CONNECT_IMMEDIATELY]) {
                 unset($options[static::CONNECT_IMMEDIATELY]);
                 $this->establishConnection();
-            }else {
+            } else {
                 unset($options[static::CONNECT_IMMEDIATELY]);
             }
         }

--- a/tests/ExtendedConnectPdoTest.php
+++ b/tests/ExtendedConnectPdoTest.php
@@ -11,6 +11,6 @@ class ExtendedConnectPdoTest extends \Aura\Sql\ExtendedPdoTest
 
     public function testPdoType()
     {
-        $this->assertInstanceOf(Pdo\Sqlite::class, $this->pdo);
+        $this->assertInstanceOf(Pdo\Sqlite::class, $this->pdo->getPdo());
     }
 }

--- a/tests/ExtendedConnectPdoTest.php
+++ b/tests/ExtendedConnectPdoTest.php
@@ -8,4 +8,9 @@ class ExtendedConnectPdoTest extends \Aura\Sql\ExtendedPdoTest
     {
         return ExtendedPdo::connect('sqlite::memory:');
     }
+
+    public function testPdoType()
+    {
+        $this->assertInstanceOf(Pdo\Sqlite::class, $this->pdo);
+    }
 }

--- a/tests/ExtendedPdoTest.php
+++ b/tests/ExtendedPdoTest.php
@@ -73,7 +73,7 @@ class ExtendedPdoTest extends TestCase
 
     public function testPdoType()
     {
-        $this->assertNotInstanceOf(Pdo\Sqlite::class, $this->pdo);
+        $this->assertNotInstanceOf(Pdo\Sqlite::class, $this->pdo->getPdo());
     }
 
     public function testCall()

--- a/tests/ExtendedPdoTest.php
+++ b/tests/ExtendedPdoTest.php
@@ -71,6 +71,11 @@ class ExtendedPdoTest extends TestCase
         $this->pdo->perform($stm, $data);
     }
 
+    public function testPdoType()
+    {
+        $this->assertNotInstanceOf(Pdo\Sqlite::class, $this->pdo);
+    }
+
     public function testCall()
     {
         if (defined('HHVM_VERSION')) {


### PR DESCRIPTION
I have done some changes to keep the behaviour the same as the PDO calls with the correct returned types for the pdo object.

Thanks to @frederikbosch as I took some of the ideas from https://github.com/auraphp/Aura.Sql/issues/228#issuecomment-2393060218, hope you don't mind