### PR TITLE
Add Psalm taint analysis annotations for SQL injection detection

### DIFF
--- a/src/ExtendedPdoInterface.php
+++ b/src/ExtendedPdoInterface.php
@@ -251,6 +251,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @return string The multi-part identifier name, quoted.
      *
+     * @psalm-taint-escape sql
      */
     public function quoteName(string $name): string;
 
@@ -262,6 +263,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @return string The quoted identifier name.
      *
+     * @psalm-taint-escape sql
      */
     public function quoteSingleName(string $name): string;
 

--- a/src/PdoInterface.php
+++ b/src/PdoInterface.php
@@ -92,6 +92,7 @@ interface PdoInterface
      *
      * @see http://php.net/manual/en/pdo.exec.php
      *
+     * @psalm-taint-sink sql $statement
      */
     public function exec(string $statement): int|false;
 
@@ -169,6 +170,7 @@ interface PdoInterface
      *
      * @see http://php.net/manual/en/pdo.query.php
      *
+     * @psalm-taint-sink sql $query
      */
     public function query(string $query, ?int $fetchMode = null, ...$fetch_mode_args): PDOStatement|false;
 

--- a/src/PdoInterface.php
+++ b/src/PdoInterface.php
@@ -153,6 +153,8 @@ interface PdoInterface
      * @return \PDOStatement|false
      *
      * @see http://php.net/manual/en/pdo.prepare.php
+     *
+     * @psalm-taint-sink sql $query
      */
     public function prepare(string $query, array $options = []): PDOStatement|false;
 
@@ -186,6 +188,7 @@ interface PdoInterface
      *
      * @see http://php.net/manual/en/pdo.quote.php
      *
+     * @psalm-taint-escape sql
      */
     public function quote(string|int|array|float|null $value, int $type = PDO::PARAM_STR): string|false;
 


### PR DESCRIPTION
## Summary

Add `@psalm-taint-sink sql` annotations to enable Psalm's taint analysis for SQL injection detection.

### Changes

- Add `@psalm-taint-sink sql $statement` to `exec()` method
- Add `@psalm-taint-sink sql $query` to `query()` method

### Purpose

These annotations allow Psalm's taint analysis to detect SQL injection vulnerabilities when user input is directly concatenated into SQL queries passed to these methods.

Example detection:
```php
$id = $_GET['id'];
$pdo->query("SELECT * FROM users WHERE id = '$id'"); // TaintedSql detected
```

Note: The `perform()` and `fetch*()` methods are not marked as sinks because they are designed for prepared statements with parameter binding, which safely escapes user input.

### References

- [Psalm Taint Analysis Documentation](https://psalm.dev/docs/security_analysis/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added static taint/security annotations to public API documentation to improve static analysis for SQL safety.
  * No changes to public method signatures or runtime behavior; changes are documentation-only and analysis-focused.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->