### PR TITLE
Add psalm taint-sink annotations to fetch*/yield*/perform methods

### DIFF
--- a/src/ExtendedPdoInterface.php
+++ b/src/ExtendedPdoInterface.php
@@ -47,6 +47,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @return int
      *
+     * @psalm-taint-sink sql $statement
      */
     public function fetchAffected(string $statement, array $values = []): int;
 
@@ -61,6 +62,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @return array
      *
+     * @psalm-taint-sink sql $statement
      */
     public function fetchAll(string $statement, array $values = []): array;
 
@@ -79,6 +81,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @return array
      *
+     * @psalm-taint-sink sql $statement
      */
     public function fetchAssoc(string $statement, array $values = []): array;
 
@@ -92,6 +95,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @return array
      *
+     * @psalm-taint-sink sql $statement
      */
     public function fetchCol(string $statement, array $values = []): array;
 
@@ -109,6 +113,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @return array
      *
+     * @psalm-taint-sink sql $statement
      */
     public function fetchGroup(
         string $statement,
@@ -137,6 +142,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @return object|false
      *
+     * @psalm-taint-sink sql $statement
      */
     public function fetchObject(
         string $statement,
@@ -168,6 +174,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @return array
      *
+     * @psalm-taint-sink sql $statement
      */
     public function fetchObjects(
         string $statement,
@@ -186,6 +193,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @return array|false
      *
+     * @psalm-taint-sink sql $statement
      */
     public function fetchOne(string $statement, array $values = []): array|false;
 
@@ -200,6 +208,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @return array
      *
+     * @psalm-taint-sink sql $statement
      */
     public function fetchPairs(string $statement, array $values = []): array;
 
@@ -213,6 +222,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @return mixed
      *
+     * @psalm-taint-sink sql $statement
      */
     public function fetchValue(string $statement, array $values = []): mixed;
 
@@ -304,6 +314,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @return \Generator
      *
+     * @psalm-taint-sink sql $statement
      */
     public function yieldAll(string $statement, array $values = []): Generator;
 
@@ -317,6 +328,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @return \Generator
      *
+     * @psalm-taint-sink sql $statement
      */
     public function yieldAssoc(string $statement, array $values = []): Generator;
 
@@ -330,6 +342,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @return \Generator
      *
+     * @psalm-taint-sink sql $statement
      */
     public function yieldCol(string $statement, array $values = []): Generator;
 
@@ -354,6 +367,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @return \Generator
      *
+     * @psalm-taint-sink sql $statement
      */
     public function yieldObjects(
         string $statement,
@@ -373,6 +387,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @return \Generator
      *
+     * @psalm-taint-sink sql $statement
      */
     public function yieldPairs(string $statement, array $values = []): Generator;
 
@@ -387,6 +402,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @return \PDOStatement
      *
+     * @psalm-taint-sink sql $statement
      */
     public function perform(string $statement, array $values = []): PDOStatement;
 
@@ -411,6 +427,7 @@ interface ExtendedPdoInterface extends PdoInterface
      *
      * @see http://php.net/manual/en/pdo.prepare.php
      *
+     * @psalm-taint-sink sql $statement
      */
     public function prepareWithValues(string $statement, array $values = []): PDOStatement;
 }


### PR DESCRIPTION
## Summary

Add `@psalm-taint-sink sql $statement` annotations to all methods that accept SQL statements, enabling static analysis tools to detect SQL injection vulnerabilities.

### Methods annotated
- `fetchAffected`, `fetchAll`, `fetchAssoc`, `fetchCol`, `fetchGroup`
- `fetchObject`, `fetchObjects`, `fetchOne`, `fetchPairs`, `fetchValue`
- `yieldAll`, `yieldAssoc`, `yieldCol`, `yieldObjects`, `yieldPairs`
- `perform`, `prepareWithValues`

### Rationale

While these methods support prepared statement bindings via the `$values` parameter, developers may still concatenate user input directly into the `$statement` string:

```php
// Vulnerable - user input directly in SQL string
$pdo->fetchAll("SELECT * FROM users WHERE name = '$name'");

// Safe - using parameter binding
$pdo->fetchAll("SELECT * FROM users WHERE name = :name", ['name' => $name]);
```

The taint-sink annotations help catch such misuse during Psalm's taint analysis.

This complements PR #248 which added annotations to `exec`, `prepare`, `query`, and `quote` methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced static analysis and code quality tracking through comprehensive annotations added to multiple interface methods, strengthening internal analysis capabilities without modifying existing functionality or user-facing features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->