### PR TITLE
Fix array placeholder skipped after type cast (issue #177)

### DIFF
--- a/src/Parser/AbstractParser.php
+++ b/src/Parser/AbstractParser.php
@@ -43,7 +43,7 @@ abstract class AbstractParser implements ParserInterface
      * @var string
      *
      */
-    protected string $skip = '/^(\'|\"|\:[^a-zA-Z_])/um';
+    protected string $skip = '/^(\'|\")/um';
 
     /**
      *
@@ -180,10 +180,9 @@ abstract class AbstractParser implements ParserInterface
     {
         $str = '';
         foreach ($subs as $i => $sub) {
-            $char = substr($sub, 0, 1);
-            if ($char == '?') {
+            if ($sub === '?') {
                 $str .= $this->prepareNumberedPlaceholder();
-            } elseif ($char == ':') {
+            } elseif (preg_match('/^:[a-zA-Z_][a-zA-Z0-9_]*$/', $sub)) {
                 $str .= $this->prepareNamedPlaceholder($sub);
             } else {
                 $str .= $sub;

--- a/src/Parser/PgsqlParser.php
+++ b/src/Parser/PgsqlParser.php
@@ -42,5 +42,5 @@ class PgsqlParser extends AbstractParser
      * @var string
      *
      */
-    protected string $skip = '/^(\'|\"|\$|\:[^a-zA-Z_])/um';
+    protected string $skip = '/^(\'|\"|\$)/um';
 }

--- a/src/Parser/SqliteParser.php
+++ b/src/Parser/SqliteParser.php
@@ -32,5 +32,5 @@ class SqliteParser extends AbstractParser
     /**
      * {@inheritDoc}
      */
-    protected string $skip = '/^(\'|"|`|\:[^a-zA-Z_])/um';
+    protected string $skip = '/^(\'|"|`)/um';
 }

--- a/tests/Parser/MysqlParserTest.php
+++ b/tests/Parser/MysqlParserTest.php
@@ -24,4 +24,32 @@ SQL;
         list ($statement, $values) = $this->rebuild($sql, $parameters);
         $this->assertEquals($sql, $statement);
     }
+
+    /**
+     * @see https://github.com/auraphp/Aura.Sql/issues/181
+     *
+     * Aura.Sql's parser only rebuilds bound placeholders; it never quotes
+     * identifiers. Expressions such as system variables (`@@session.time_zone`)
+     * and function calls with keywords (`COUNT(DISTINCT ...)`) must pass through
+     * verbatim, with no backticks added. (Identifier quoting reported in the
+     * issue belongs to the separate Aura.SqlQuery package.)
+     */
+    public function testDoesNotQuoteExpressions()
+    {
+        $parameters = ['tz' => 'UTC'];
+
+        $sql = "SELECT CONVERT_TZ(open_from, customer.time_zone, @@session.time_zone) AS open_now"
+             . " FROM customer WHERE customer.time_zone = :tz";
+        list ($statement, $values) = $this->rebuild($sql, $parameters);
+        $expectedStatement = "SELECT CONVERT_TZ(open_from, customer.time_zone, @@session.time_zone) AS open_now"
+             . " FROM customer WHERE customer.time_zone = :tz";
+        $this->assertEquals($expectedStatement, $statement);
+        $this->assertEquals(['tz' => 'UTC'], $values);
+
+        $sql = "SELECT COUNT(DISTINCT customer_id) FROM orders WHERE status = :status";
+        list ($statement, $values) = $this->rebuild($sql, ['status' => 'paid']);
+        $expectedStatement = "SELECT COUNT(DISTINCT customer_id) FROM orders WHERE status = :status";
+        $this->assertEquals($expectedStatement, $statement);
+        $this->assertEquals(['status' => 'paid'], $values);
+    }
 }

--- a/tests/Parser/PgsqlParserTest.php
+++ b/tests/Parser/PgsqlParserTest.php
@@ -92,4 +92,62 @@ SQL;
         list ($statement, $values) = $this->rebuild($sql, $parameters);
         $this->assertEquals($sql, $statement);
     }
+
+    /**
+     * @see https://github.com/auraphp/Aura.Sql/issues/177
+     *
+     * A named array placeholder that appears after a type cast (`::`) which
+     * immediately follows a string literal must still be expanded. Previously
+     * the query part beginning with `::` was skipped entirely, so any
+     * placeholder later in that same part was left untouched.
+     */
+    public function testArrayPlaceholderAfterTypeCast()
+    {
+        $parameters = ['types' => [1, 2]];
+        $sql = "SELECT id FROM table WHERE removed = false"
+             . " AND data @> '{\"is_hidden\":false}'::jsonb"
+             . " AND type IN (:types)";
+        list ($statement, $values) = $this->rebuild($sql, $parameters);
+        $expectedStatement = "SELECT id FROM table WHERE removed = false"
+             . " AND data @> '{\"is_hidden\":false}'::jsonb"
+             . " AND type IN (:types_0, :types_1)";
+        $expectedValues = ['types_0' => 1, 'types_1' => 2];
+        $this->assertEquals($expectedStatement, $statement);
+        $this->assertEquals($expectedValues, $values);
+    }
+
+    /**
+     * @see https://github.com/auraphp/Aura.Sql/issues/177
+     *
+     * The reordered query from the issue discussion worked before the fix;
+     * make sure it keeps working afterwards.
+     */
+    public function testArrayPlaceholderBeforeTypeCast()
+    {
+        $parameters = ['types' => [1, 2]];
+        $sql = "SELECT id FROM table WHERE type IN (:types)"
+             . " AND removed = false"
+             . " AND data @> '{\"is_hidden\":false}'::jsonb";
+        list ($statement, $values) = $this->rebuild($sql, $parameters);
+        $expectedStatement = "SELECT id FROM table WHERE type IN (:types_0, :types_1)"
+             . " AND removed = false"
+             . " AND data @> '{\"is_hidden\":false}'::jsonb";
+        $expectedValues = ['types_0' => 1, 'types_1' => 2];
+        $this->assertEquals($expectedStatement, $statement);
+        $this->assertEquals($expectedValues, $values);
+    }
+
+    /**
+     * A scalar placeholder following a `::` cast must also survive.
+     */
+    public function testScalarPlaceholderAfterTypeCast()
+    {
+        $parameters = ['id' => 42];
+        $sql = "SELECT 'hello'::TEXT AS greeting WHERE id = :id";
+        list ($statement, $values) = $this->rebuild($sql, $parameters);
+        $expectedStatement = "SELECT 'hello'::TEXT AS greeting WHERE id = :id";
+        $expectedValues = ['id' => 42];
+        $this->assertEquals($expectedStatement, $statement);
+        $this->assertEquals($expectedValues, $values);
+    }
 }


### PR DESCRIPTION
A named or numbered array placeholder appearing after a `::` type cast that immediately follows a string literal was left unexpanded. For example:

    SELECT id FROM t WHERE data @> '{"k":false}'::jsonb AND type IN (:types)

produced a "bind message supplies 0 parameters" error because `:types` was never rebuilt.

Root cause: getParts() splits the string literal off as its own part, leaving the following part starting with `::`. The `skip` regex matched that leading `::` (via the `\:[^a-zA-Z_]` clause) and returned the entire part verbatim, so any placeholder later in the part was ignored. Additionally, prepareValuePlaceholders() classified sub-parts by their first character only, which would misread literal text beginning with `:` (e.g. `::TEXT`, `:]`) as a placeholder.

Fix:
- Drop the over-broad `\:[^a-zA-Z_]` clause from the skip regexes in AbstractParser, PgsqlParser and SqliteParser so cast parts are still parsed. (MysqlParser already omitted this clause.)
- Classify sub-parts precisely: a numbered placeholder is exactly `?`, and a named placeholder must fully match `:[a-zA-Z_][a-zA-Z0-9_]*`. The `(?<!:)` lookbehind in the split already prevents `::casts` from being captured.

Also adds a regression test verifying the parser never quotes expressions such as `@@session.time_zone` or `COUNT(DISTINCT ...)` (issue auraphp/Aura.SqlQuery#226; identifier quoting there belongs to the separate Aura.SqlQuery package).


Claude-Session: https://claude.ai/code/session_01Npq3woU2JKWXMCHnQsytSx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL parsing around PostgreSQL type casts and placeholders.
  * Prevented incorrect quoting of MySQL expressions, system variables, and function calls.
  * Improved handling of quoted and special SQL segments across supported databases.
* **Tests**
  * Added regression coverage for array and scalar placeholders used with PostgreSQL type casts.
  * Added coverage confirming SQL expressions remain unchanged during query rebuilding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->