### PR TITLE
Add the shared Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+# Releasing this package: Actions -> Release -> Run workflow, pick the branch
+# (6.x) and type the version. Or from a terminal:
+#
+#     gh workflow run release.yml --ref 6.x -f version=6.0.2
+#
+# The shared workflow creates the tag itself, and only after every check has
+# passed. Do not tag by hand -- Packagist derives versions from tags, so a tag
+# is a published version the moment it exists.
+#
+# Release notes come from this package's own CHANGELOG.md. The version you type
+# must match the version at the top of the change log -- or, for a pre-release
+# such as 6.1.0-alpha1, its base version, so that alphas and betas do not each
+# need a change log section of their own.
+
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, e.g. 6.0.2'
+        required: true
+        type: string
+
+jobs:
+  release:
+    uses: auraphp/bin/.github/workflows/release.yml@v1.0.0
+    permissions:
+      contents: write
+    with:
+      version: ${{ inputs.version }}


### PR DESCRIPTION
This package had no release workflow, so cutting a release meant tagging by hand — which is exactly what the shared workflow exists to prevent. Packagist derives versions from tags, so a tag is a published version the moment it exists, and checks that run *after* a tag push cannot un-publish anything. The shared workflow creates the tag last, from the exact commit that passed every check.

Adds `.github/workflows/release.yml`, calling `auraphp/bin/.github/workflows/release.yml@v1.0.0`. It is the same caller Aura.Filter uses, with no per-package tuning — the defaults fit.

## Checked, not assumed

- **PHP 8.4.** The shared workflow's pre-release test run defaults to PHP 8.4. The suite was run on 8.4 here: **OK (191 tests, 437 assertions)**. `require.php` is `^8.4`.
- **Change log.** `CHANGELOG.md` carries parseable `## N.N.N` headings; the top one resolves to `6.0.1`, so the release-notes step has something to extract.

## Releasing

Actions → Release → Run workflow, pick `6.x`, type the version. Or:

```
gh workflow run release.yml --ref 6.x -f version=6.0.2
```

The version typed must match the version at the top of `CHANGELOG.md` (or, for a pre-release like `6.1.0-alpha1`, its base version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lgup8xLZHLQmavt7JoEQ4C

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lgup8xLZHLQmavt7JoEQ4C)_